### PR TITLE
feat: [PAY-217] add rate limiting

### DIFF
--- a/src/app/api/did/verify/route.ts
+++ b/src/app/api/did/verify/route.ts
@@ -29,6 +29,7 @@ export const runtime = 'nodejs'
 // import { DID } from 'dids'
 // import * as KeyResolver from 'key-did-resolver'
 // import { decodeJwsPayload } from 'did-jwt'
+// test
 export async function POST(req: Request) {
   try {
     const { did, jws } = await req.json()
@@ -38,7 +39,7 @@ export async function POST(req: Request) {
     const result = await verifier.verifyJWS(jws)
 
     // 👇 this was failing before
-    const payload = decodeJwsPayload(result.payload)
+    // const payload = decodeJwsPayload(result.payload)
 
     if (!payload?.challenge) {
       return NextResponse.json({ error: 'no challenge' }, { status: 401 })


### PR DESCRIPTION
Acceptance Criteria
- [ ] 100 req/min per API key
- [ ] 429 with {"error":"rate_limited"}
- [ ] Counter resets every minute

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Temporarily disabled JWS payload decoding in the DID verify endpoint to stop the previous failure and unblock PAY-217 rate-limiting work. The endpoint will return 401 {"error":"no challenge"} until decoding is restored.

<!-- End of auto-generated description by cubic. -->

